### PR TITLE
Add CirC stdlib to nn_steps compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,14 @@ Beside building, the `docker.sh` script allows to spawn a shell in the container
 or run the evaluation:
 
 ```
-./docker.sh eval 
+./docker.sh eval
 ```
+
+Compilation of the neural network step circuits relies on CirC's ZSharp
+standard library.  Set the environment variable `CIRC_STDLIB` to the path of
+this library when running outside of the Docker container.  The default path is
+`/root/circ/stdlib`.
+
 ## Running a Sample Experiment
 
 After installing the requirements (or using the Docker image), you can run a minimal example:

--- a/src/nn_steps.py
+++ b/src/nn_steps.py
@@ -1,5 +1,7 @@
 import argparse
 import json
+import os
+import shutil
 from pathlib import Path
 from jinja2 import Template
 from circ import CirC
@@ -66,6 +68,15 @@ def params_for_step(step: str, cfg):
 def compile_step(step: str, cfg):
     working_dir = cfg['working_dir'].joinpath(step)
     working_dir.mkdir(parents=True, exist_ok=True)
+    repo_root = Path(__file__).resolve().parent.parent
+    poseidon_src = repo_root.joinpath('templates', 'poseidon')
+    if poseidon_src.exists():
+        shutil.copytree(poseidon_src, working_dir.joinpath('poseidon'), dirs_exist_ok=True)
+    stdlib_src = Path(os.environ.get('CIRC_STDLIB', '/root/circ/stdlib'))
+    if stdlib_src.exists():
+        shutil.copytree(stdlib_src, working_dir.joinpath('stdlib'), dirs_exist_ok=True)
+    else:
+        raise FileNotFoundError(f"std library not found: {stdlib_src}")
     circ = CirC(cfg['circ_path'], debug=cfg['debug'])
     proof_src = render_step(step, cfg)
     working_dir.joinpath('circuit.zok').write_text(proof_src)


### PR DESCRIPTION
## Summary
- copy templates/poseidon and the CirC ZSharp stdlib before compiling NN steps
- document `CIRC_STDLIB` environment variable

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687e7b96432083328588dfe2d55cbdb4